### PR TITLE
feat: Add dynamic PVC management with configurable cleanup for pipeline runs

### DIFF
--- a/src/main/java/com/redhat/sast/api/platform/KubernetesResourceManager.java
+++ b/src/main/java/com/redhat/sast/api/platform/KubernetesResourceManager.java
@@ -1,0 +1,186 @@
+package com.redhat.sast.api.platform;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.tekton.client.TektonClient;
+import jakarta.annotation.Nonnull;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Manages Kubernetes resources lifecycle including PVCs and PipelineRuns.
+ * Handles creation, cleanup, and lifecycle management of platform resources.
+ */
+@ApplicationScoped
+public class KubernetesResourceManager {
+
+    private static final Logger LOG = Logger.getLogger(KubernetesResourceManager.class);
+
+    @Inject
+    TektonClient tektonClient;
+
+    @ConfigProperty(name = "sast.ai.workflow.namespace")
+    String namespace;
+
+    /**
+     * AutoCloseable wrapper for PVC resources to ensure cleanup in case of failures
+     */
+    public class PvcResource implements AutoCloseable {
+        private final String pvcName;
+        private boolean shouldCleanup;
+
+        public PvcResource(String pvcName) {
+            this.pvcName = pvcName;
+            this.shouldCleanup = true;
+        }
+
+        public String getName() {
+            return pvcName;
+        }
+
+        public void disableAutoCleanup() {
+            this.shouldCleanup = false;
+        }
+
+        @Override
+        public void close() {
+            if (shouldCleanup && pvcName != null) {
+                deletePVC(pvcName);
+            }
+        }
+    }
+
+    /**
+     * Creates a dedicated PVC with the specified name and size.
+     *
+     * @param pvcName the name for the PVC
+     * @param size the storage size (e.g., "20Gi")
+     * @return the created PVC name
+     * @throws IllegalStateException if PVC creation fails
+     */
+    public String createPVC(@Nonnull String pvcName, @Nonnull String size) {
+        try {
+            KubernetesClient k8sClient = tektonClient.adapt(KubernetesClient.class);
+
+            PersistentVolumeClaim pvc = new PersistentVolumeClaimBuilder()
+                    .withNewMetadata()
+                    .withName(pvcName)
+                    .withNamespace(namespace)
+                    .endMetadata()
+                    .withNewSpec()
+                    .withAccessModes("ReadWriteOnce")
+                    .withNewResources()
+                    .addToRequests("storage", new Quantity(size))
+                    .endResources()
+                    .endSpec()
+                    .build();
+
+            PersistentVolumeClaim createdPvc = k8sClient
+                    .persistentVolumeClaims()
+                    .inNamespace(namespace)
+                    .resource(pvc)
+                    .create();
+
+            LOG.infof("Created PVC: %s with size: %s in namespace: %s", pvcName, size, namespace);
+            return createdPvc.getMetadata().getName();
+        } catch (Exception e) {
+            LOG.errorf(e, "Failed to create PVC: %s", pvcName);
+            throw new IllegalStateException("Failed to create PVC: " + pvcName, e);
+        }
+    }
+
+    /**
+     * Creates a PVC wrapped in an AutoCloseable resource for automatic cleanup.
+     *
+     * @param pvcName the name for the PVC
+     * @param size the storage size (e.g., "20Gi")
+     * @return PvcResource that automatically cleans up on close()
+     */
+    public PvcResource createManagedPVC(@Nonnull String pvcName, @Nonnull String size) {
+        String createdPvcName = createPVC(pvcName, size);
+        return new PvcResource(createdPvcName);
+    }
+
+    /**
+     * Deletes a PVC by name.
+     *
+     * @param pvcName the name of the PVC to delete
+     */
+    public void deletePVC(@Nonnull String pvcName) {
+        try {
+            KubernetesClient k8sClient = tektonClient.adapt(KubernetesClient.class);
+
+            boolean deleted = !k8sClient
+                    .persistentVolumeClaims()
+                    .inNamespace(namespace)
+                    .withName(pvcName)
+                    .delete()
+                    .isEmpty();
+
+            if (deleted) {
+                LOG.infof("Successfully deleted PVC: %s", pvcName);
+            } else {
+                LOG.warnf("PVC %s was not found or already deleted", pvcName);
+            }
+        } catch (Exception e) {
+            LOG.errorf(e, "Failed to delete PVC: %s", pvcName);
+        }
+    }
+
+    /**
+     * Deletes a PipelineRun by name.
+     * Includes a brief wait for pod cleanup.
+     *
+     * @param pipelineRunName the name of the PipelineRun to delete
+     */
+    public void deletePipelineRun(@Nonnull String pipelineRunName) {
+        try {
+            boolean deleted = !tektonClient
+                    .v1()
+                    .pipelineRuns()
+                    .inNamespace(namespace)
+                    .withName(pipelineRunName)
+                    .delete()
+                    .isEmpty();
+
+            if (deleted) {
+                LOG.infof("Successfully deleted PipelineRun: %s", pipelineRunName);
+                // Wait a moment for pods to be cleaned up
+                try {
+                    Thread.sleep(2000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    LOG.warnf("Cleanup sleep interrupted for PipelineRun: %s", pipelineRunName);
+                }
+            } else {
+                LOG.warnf("PipelineRun %s was not found or already deleted", pipelineRunName);
+            }
+        } catch (Exception e) {
+            LOG.errorf(e, "Failed to delete PipelineRun: %s", pipelineRunName);
+        }
+    }
+
+    /**
+     * Cleans up both PVCs associated with a pipeline run.
+     *
+     * @param pipelineRunName the base name of the pipeline run
+     */
+    public void cleanupPipelineRunPVCs(@Nonnull String pipelineRunName) {
+        deletePVC(pipelineRunName + "-shared");
+        deletePVC(pipelineRunName + "-cache");
+    }
+
+    /**
+     * Gets the configured namespace for resource operations.
+     *
+     * @return the namespace
+     */
+    public String getNamespace() {
+        return namespace;
+    }
+}

--- a/src/main/java/com/redhat/sast/api/platform/PipelineParameterMapper.java
+++ b/src/main/java/com/redhat/sast/api/platform/PipelineParameterMapper.java
@@ -1,0 +1,204 @@
+package com.redhat.sast.api.platform;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import com.redhat.sast.api.model.Job;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.tekton.client.TektonClient;
+import io.fabric8.tekton.v1.Param;
+import io.fabric8.tekton.v1.ParamBuilder;
+import jakarta.annotation.Nonnull;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Maps Job domain objects to Tekton pipeline parameters.
+ * Handles the transformation of job data and settings into pipeline-specific parameter format.
+ */
+@ApplicationScoped
+public class PipelineParameterMapper {
+
+    private static final Logger LOG = Logger.getLogger(PipelineParameterMapper.class);
+
+    // Pipeline parameter names
+    private static final String PARAM_REPO_REMOTE_URL = "REPO_REMOTE_URL";
+    private static final String PARAM_FALSE_POSITIVES_URL = "FALSE_POSITIVES_URL";
+    private static final String PARAM_INPUT_REPORT_FILE_PATH = "INPUT_REPORT_FILE_PATH";
+    private static final String PARAM_PROJECT_NAME = "PROJECT_NAME";
+    private static final String PARAM_PROJECT_VERSION = "PROJECT_VERSION";
+    private static final String PARAM_LLM_URL = "LLM_URL";
+    private static final String PARAM_LLM_MODEL_NAME = "LLM_MODEL_NAME";
+    private static final String PARAM_LLM_API_KEY = "LLM_API_KEY";
+    private static final String PARAM_EMBEDDINGS_LLM_URL = "EMBEDDINGS_LLM_URL";
+    private static final String PARAM_EMBEDDINGS_LLM_MODEL_NAME = "EMBEDDINGS_LLM_MODEL_NAME";
+    private static final String PARAM_EMBEDDINGS_LLM_API_KEY = "EMBEDDINGS_LLM_API_KEY";
+
+    @Inject
+    TektonClient tektonClient;
+
+    @ConfigProperty(name = "sast.ai.workflow.namespace")
+    String namespace;
+
+    /**
+     * Extracts and converts Job data to pipeline parameters.
+     *
+     * @param job the job containing data to be converted
+     * @return list of pipeline parameters
+     */
+    public List<Param> extractPipelineParams(@Nonnull Job job) {
+        List<Param> params = new ArrayList<>();
+
+        addBasicJobParameters(params, job);
+        addLlmParameters(params, job);
+
+        return params;
+    }
+
+    /**
+     * Adds basic job-related pipeline parameters.
+     */
+    private void addBasicJobParameters(List<Param> params, Job job) {
+        params.add(createParam(PARAM_REPO_REMOTE_URL, job.getPackageSourceCodeUrl()));
+        params.add(createParam(PARAM_FALSE_POSITIVES_URL, job.getKnownFalsePositivesUrl()));
+        params.add(createParam(PARAM_INPUT_REPORT_FILE_PATH, job.getgSheetUrl()));
+        params.add(createParam(PARAM_PROJECT_NAME, job.getProjectName()));
+        params.add(createParam(PARAM_PROJECT_VERSION, job.getProjectVersion()));
+    }
+
+    /**
+     * Adds LLM-related pipeline parameters based on job settings.
+     */
+    private void addLlmParameters(List<Param> params, Job job) {
+        if (job.getJobSettings() != null) {
+            addLlmParametersWithSettings(params, job);
+        } else {
+            addDefaultLlmParameters(params, job);
+        }
+    }
+
+    /**
+     * Adds LLM parameters when JobSettings are available.
+     */
+    private void addLlmParametersWithSettings(List<Param> params, Job job) {
+        String secretName = job.getJobSettings().getSecretName();
+        LOG.infof("Job %d has JobSettings with secretName: '%s'", job.getId(), secretName);
+
+        LlmSecretValues llmSecretValues = getLlmSecretValues(secretName);
+
+        // Main LLM parameters
+        params.add(createParam(PARAM_LLM_URL, llmSecretValues.llmUrl()));
+        params.add(createParam(
+                PARAM_LLM_MODEL_NAME,
+                getModelNameWithFallback(job.getJobSettings().getLlmModelName(), llmSecretValues.llmModelName())));
+        params.add(createParam(PARAM_LLM_API_KEY, llmSecretValues.llmApiKey()));
+
+        // Embeddings LLM parameters
+        params.add(createParam(PARAM_EMBEDDINGS_LLM_URL, llmSecretValues.embeddingsUrl()));
+        params.add(createParam(
+                PARAM_EMBEDDINGS_LLM_MODEL_NAME,
+                getModelNameWithFallback(
+                        job.getJobSettings().getEmbeddingLlmModelName(), llmSecretValues.embeddingsModelName())));
+        params.add(createParam(PARAM_EMBEDDINGS_LLM_API_KEY, llmSecretValues.embeddingsApiKey()));
+    }
+
+    /**
+     * Adds default empty LLM parameters when JobSettings are not available.
+     */
+    private void addDefaultLlmParameters(List<Param> params, Job job) {
+        LOG.warnf("Job %d has NO JobSettings - using empty LLM values", job.getId());
+
+        params.add(createParam(PARAM_LLM_URL, ""));
+        params.add(createParam(PARAM_LLM_MODEL_NAME, ""));
+        params.add(createParam(PARAM_LLM_API_KEY, ""));
+        params.add(createParam(PARAM_EMBEDDINGS_LLM_URL, ""));
+        params.add(createParam(PARAM_EMBEDDINGS_LLM_MODEL_NAME, ""));
+        params.add(createParam(PARAM_EMBEDDINGS_LLM_API_KEY, ""));
+    }
+
+    /**
+     * Helper method to create a pipeline parameter.
+     */
+    private Param createParam(String name, String value) {
+        return new ParamBuilder()
+                .withName(name)
+                .withNewValue(value != null ? value : "")
+                .build();
+    }
+
+    /**
+     * Reads LLM configuration from Kubernetes secret.
+     */
+    private LlmSecretValues getLlmSecretValues(String secretName) {
+        try {
+            if (secretName == null || secretName.trim().isEmpty()) {
+                LOG.warnf("Secret name is null or empty");
+                return LlmSecretValues.empty();
+            }
+
+            // Use the underlying Kubernetes client from TektonClient to access secrets
+            Secret secret = tektonClient
+                    .adapt(KubernetesClient.class)
+                    .secrets()
+                    .inNamespace(namespace)
+                    .withName(secretName)
+                    .get();
+            if (secret == null) {
+                LOG.warnf("Secret '%s' not found in namespace '%s'", secretName, namespace);
+                return LlmSecretValues.empty();
+            }
+
+            if (secret.getData() == null) {
+                LOG.warnf("Secret '%s' has no data", secretName);
+                return LlmSecretValues.empty();
+            }
+
+            // Extract and decode all values in one pass
+            String llmUrl = getDecodedSecretValue(secret, "llm_url");
+            String llmApiKey = getDecodedSecretValue(secret, "llm_api_key");
+            String embeddingsUrl = getDecodedSecretValue(secret, "embeddings_llm_url");
+            String embeddingsApiKey = getDecodedSecretValue(secret, "embeddings_llm_api_key");
+            String llmModelName = getDecodedSecretValue(secret, "llm_model_name");
+            String embeddingsModelName = getDecodedSecretValue(secret, "embedding_llm_model_name");
+
+            return new LlmSecretValues(
+                    llmUrl, llmApiKey, embeddingsUrl, embeddingsApiKey, llmModelName, embeddingsModelName);
+        } catch (Exception e) {
+            LOG.errorf(e, "Failed to read secret '%s' from namespace '%s'", secretName, namespace);
+            return LlmSecretValues.empty();
+        }
+    }
+
+    private String getDecodedSecretValue(Secret secret, String key) {
+        try {
+            if (!secret.getData().containsKey(key)) {
+                LOG.debugf(
+                        "Secret '%s' does not contain key '%s'",
+                        secret.getMetadata().getName(), key);
+                return "";
+            }
+
+            String encodedValue = secret.getData().get(key);
+            return new String(java.util.Base64.getDecoder().decode(encodedValue), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to decode secret value for key '%s'", key);
+            return "";
+        }
+    }
+
+    /**
+     * Gets model name with fallback: JobSettings first, then secret value
+     */
+    private String getModelNameWithFallback(String jobSettingsValue, String secretValue) {
+        if (jobSettingsValue != null && !jobSettingsValue.trim().isEmpty()) {
+            return jobSettingsValue;
+        }
+        return secretValue != null ? secretValue : "";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,10 @@ quarkus.application.version=${project.version}
 sast.ai.workflow.namespace=${SAST_AI_WORKFLOW_NAMESPACE:sast-ai}
 quarkus.log.category."org.jboss.logging".level=DEBUG
 quarkus.kubernetes-client.trust-certs=false
+
+# PVC storage configuration
+sast.ai.workspace.shared.size=20Gi
+sast.ai.workspace.cache.size=10Gi
+
+# Cleanup configuration
+sast.ai.cleanup.completed.pipelineruns=true


### PR DESCRIPTION
introduce dynamic PVC creation and cleanup for each pipeline run to improve resource isolation and management.

##  Features Added

- **Dynamic PVC Creation**: Each pipeline run now gets dedicated PVCs instead of shared ones
 - `shared-workspace`: Configurable size (default: 20Gi)
 - `cache-workspace`: Configurable size (default: 10Gi)
- **Automatic Resource Cleanup**: PVCs and PipelineRuns are automatically deleted after completion
- **Configurable Cleanup**: Option to keep PipelineRuns for debugging purposes
- **Default Storage Class**: Uses cluster's default storage class automatically

##  Configuration Options

```properties
# PVC sizes
sast.ai.workspace.shared.size=20Gi
sast.ai.workspace.cache.size=10Gi

# Cleanup behavior
sast.ai.cleanup.completed.pipelineruns=true
```