### PR TITLE
feat: add optional boolean useKnownFalsePositiveFile parameter for both types of requests (single job and batch)

### DIFF
--- a/src/main/java/com/redhat/sast/api/model/JobBatch.java
+++ b/src/main/java/com/redhat/sast/api/model/JobBatch.java
@@ -41,6 +41,9 @@ public class JobBatch {
     @Column(name = "last_updated_at")
     private LocalDateTime lastUpdatedAt;
 
+    @Column(name = "use_known_false_positive_file")
+    private Boolean useKnownFalsePositiveFile;
+
     @OneToMany(mappedBy = "jobBatch", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Job> jobs;
 
@@ -131,8 +134,19 @@ public class JobBatch {
         this.lastUpdatedAt = lastUpdatedAt;
     }
 
+    public Boolean getUseKnownFalsePositiveFile() {
+        return useKnownFalsePositiveFile;
+    }
+
+    public void setUseKnownFalsePositiveFile(Boolean useKnownFalsePositiveFile) {
+        this.useKnownFalsePositiveFile = useKnownFalsePositiveFile;
+    }
+
     public List<Job> getJobs() {
-        return jobs != null ? new ArrayList<>(jobs) : new ArrayList<>();
+        if (jobs == null) {
+            jobs = new ArrayList<>();
+        }
+        return jobs;
     }
 
     public void setJobs(List<Job> jobs) {

--- a/src/main/java/com/redhat/sast/api/model/JobSettings.java
+++ b/src/main/java/com/redhat/sast/api/model/JobSettings.java
@@ -35,6 +35,9 @@ public class JobSettings {
     @Column(name = "secret_name")
     private String secretName;
 
+    @Column(name = "use_known_false_positive_file")
+    private Boolean useKnownFalsePositiveFile;
+
     public JobSettings() {}
 
     public Long getId() {
@@ -107,5 +110,13 @@ public class JobSettings {
 
     public void setSecretName(String secretName) {
         this.secretName = secretName;
+    }
+
+    public Boolean getUseKnownFalsePositiveFile() {
+        return useKnownFalsePositiveFile;
+    }
+
+    public void setUseKnownFalsePositiveFile(Boolean useKnownFalsePositiveFile) {
+        this.useKnownFalsePositiveFile = useKnownFalsePositiveFile;
     }
 }

--- a/src/main/java/com/redhat/sast/api/platform/PipelineParameterMapper.java
+++ b/src/main/java/com/redhat/sast/api/platform/PipelineParameterMapper.java
@@ -39,6 +39,7 @@ public class PipelineParameterMapper {
     private static final String PARAM_EMBEDDINGS_LLM_URL = "EMBEDDINGS_LLM_URL";
     private static final String PARAM_EMBEDDINGS_LLM_MODEL_NAME = "EMBEDDINGS_LLM_MODEL_NAME";
     private static final String PARAM_EMBEDDINGS_LLM_API_KEY = "EMBEDDINGS_LLM_API_KEY";
+    private static final String PARAM_USE_KNOWN_FALSE_POSITIVE_FILE = "USE_KNOWN_FALSE_POSITIVE_FILE";
 
     @Inject
     TektonClient tektonClient;
@@ -70,6 +71,9 @@ public class PipelineParameterMapper {
         params.add(createParam(PARAM_INPUT_REPORT_FILE_PATH, job.getgSheetUrl()));
         params.add(createParam(PARAM_PROJECT_NAME, job.getProjectName()));
         params.add(createParam(PARAM_PROJECT_VERSION, job.getProjectVersion()));
+
+        Boolean useKnownFalsePositiveFile = getUseKnownFalsePositiveFileValue(job);
+        params.add(createParam(PARAM_USE_KNOWN_FALSE_POSITIVE_FILE, useKnownFalsePositiveFile.toString()));
     }
 
     /**
@@ -200,5 +204,15 @@ public class PipelineParameterMapper {
             return jobSettingsValue;
         }
         return secretValue != null ? secretValue : "";
+    }
+
+    /**
+     * Gets the USE_KNOWN_FALSE_POSITIVE_FILE value with fallback to true
+     */
+    private Boolean getUseKnownFalsePositiveFileValue(Job job) {
+        if (job.getJobSettings() != null && job.getJobSettings().getUseKnownFalsePositiveFile() != null) {
+            return job.getJobSettings().getUseKnownFalsePositiveFile();
+        }
+        return true;
     }
 }

--- a/src/main/java/com/redhat/sast/api/service/JobService.java
+++ b/src/main/java/com/redhat/sast/api/service/JobService.java
@@ -78,6 +78,8 @@ public class JobService {
             settings.setEmbeddingLlmModelName(
                     jobCreationDto.getWorkflowSettings().getEmbeddingsLlmModelName());
             settings.setSecretName(jobCreationDto.getWorkflowSettings().getSecretName());
+            settings.setUseKnownFalsePositiveFile(
+                    jobCreationDto.getWorkflowSettings().getUseKnownFalsePositiveFile());
             jobSettingsRepository.persist(settings);
 
             // Manually set the JobSettings on the Job object to avoid lazy loading issues

--- a/src/main/java/com/redhat/sast/api/v1/dto/request/JobBatchSubmissionDto.java
+++ b/src/main/java/com/redhat/sast/api/v1/dto/request/JobBatchSubmissionDto.java
@@ -13,11 +13,20 @@ public class JobBatchSubmissionDto {
     @JsonProperty("submittedBy")
     private String submittedBy;
 
+    @JsonProperty("useKnownFalsePositiveFile")
+    private Boolean useKnownFalsePositiveFile;
+
     public JobBatchSubmissionDto() {}
 
     public JobBatchSubmissionDto(String batchGoogleSheetUrl, String submittedBy) {
         this.batchGoogleSheetUrl = batchGoogleSheetUrl;
         this.submittedBy = submittedBy;
+    }
+
+    public JobBatchSubmissionDto(String batchGoogleSheetUrl, String submittedBy, Boolean useKnownFalsePositiveFile) {
+        this.batchGoogleSheetUrl = batchGoogleSheetUrl;
+        this.submittedBy = submittedBy;
+        this.useKnownFalsePositiveFile = useKnownFalsePositiveFile;
     }
 
     public String getBatchGoogleSheetUrl() {
@@ -34,5 +43,13 @@ public class JobBatchSubmissionDto {
 
     public void setSubmittedBy(String submittedBy) {
         this.submittedBy = submittedBy;
+    }
+
+    public Boolean getUseKnownFalsePositiveFile() {
+        return useKnownFalsePositiveFile;
+    }
+
+    public void setUseKnownFalsePositiveFile(Boolean useKnownFalsePositiveFile) {
+        this.useKnownFalsePositiveFile = useKnownFalsePositiveFile;
     }
 }

--- a/src/main/java/com/redhat/sast/api/v1/dto/request/WorkflowSettingsDto.java
+++ b/src/main/java/com/redhat/sast/api/v1/dto/request/WorkflowSettingsDto.java
@@ -13,6 +13,9 @@ public class WorkflowSettingsDto {
     @JsonProperty("secretName")
     private String secretName;
 
+    @JsonProperty("useKnownFalsePositiveFile")
+    private Boolean useKnownFalsePositiveFile;
+
     public WorkflowSettingsDto() {}
 
     public WorkflowSettingsDto(String llmModelName, String embeddingsLlmModelName, String secretName) {
@@ -21,11 +24,20 @@ public class WorkflowSettingsDto {
         this.secretName = secretName;
     }
 
+    public WorkflowSettingsDto(
+            String llmModelName, String embeddingsLlmModelName, String secretName, Boolean useKnownFalsePositiveFile) {
+        this.llmModelName = llmModelName;
+        this.embeddingsLlmModelName = embeddingsLlmModelName;
+        this.secretName = secretName;
+        this.useKnownFalsePositiveFile = useKnownFalsePositiveFile;
+    }
+
     public WorkflowSettingsDto(WorkflowSettingsDto other) {
         if (other != null) {
             this.llmModelName = other.llmModelName;
             this.embeddingsLlmModelName = other.embeddingsLlmModelName;
             this.secretName = other.secretName;
+            this.useKnownFalsePositiveFile = other.useKnownFalsePositiveFile;
         }
     }
 
@@ -51,5 +63,13 @@ public class WorkflowSettingsDto {
 
     public void setSecretName(String secretName) {
         this.secretName = secretName;
+    }
+
+    public Boolean getUseKnownFalsePositiveFile() {
+        return useKnownFalsePositiveFile;
+    }
+
+    public void setUseKnownFalsePositiveFile(Boolean useKnownFalsePositiveFile) {
+        this.useKnownFalsePositiveFile = useKnownFalsePositiveFile;
     }
 }


### PR DESCRIPTION
The parameter is optional - defaults to True -> the default is to use known false positives and I added the option to disable it.
In order to do that I needed to make some changes to the Tekton pipeline so I created a separate PR for that in the sast-ai-workflow project. 