### PR TITLE
fix: configure falsePositivesUrl to blank for packages missing known …

### DIFF
--- a/src/main/java/com/redhat/sast/api/platform/PipelineParameterMapper.java
+++ b/src/main/java/com/redhat/sast/api/platform/PipelineParameterMapper.java
@@ -68,7 +68,8 @@ public class PipelineParameterMapper {
         params.add(createParam(PARAM_REPO_REMOTE_URL, job.getPackageSourceCodeUrl()));
 
         Boolean useKnownFalsePositiveFile = getUseKnownFalsePositiveFileValue(job);
-        String falsePositivesUrl = useKnownFalsePositiveFile ? job.getKnownFalsePositivesUrl() : "";
+        String falsePositivesUrl =
+                Boolean.TRUE.equals(useKnownFalsePositiveFile) ? job.getKnownFalsePositivesUrl() : "";
         params.add(createParam(PARAM_FALSE_POSITIVES_URL, falsePositivesUrl));
 
         params.add(createParam(PARAM_INPUT_REPORT_FILE_PATH, job.getGSheetUrl()));

--- a/src/main/java/com/redhat/sast/api/platform/PipelineParameterMapper.java
+++ b/src/main/java/com/redhat/sast/api/platform/PipelineParameterMapper.java
@@ -66,12 +66,15 @@ public class PipelineParameterMapper {
      */
     private void addBasicJobParameters(List<Param> params, Job job) {
         params.add(createParam(PARAM_REPO_REMOTE_URL, job.getPackageSourceCodeUrl()));
-        params.add(createParam(PARAM_FALSE_POSITIVES_URL, job.getKnownFalsePositivesUrl()));
+
+        Boolean useKnownFalsePositiveFile = getUseKnownFalsePositiveFileValue(job);
+        String falsePositivesUrl = useKnownFalsePositiveFile ? job.getKnownFalsePositivesUrl() : "";
+        params.add(createParam(PARAM_FALSE_POSITIVES_URL, falsePositivesUrl));
+
         params.add(createParam(PARAM_INPUT_REPORT_FILE_PATH, job.getGSheetUrl()));
         params.add(createParam(PARAM_PROJECT_NAME, job.getProjectName()));
         params.add(createParam(PARAM_PROJECT_VERSION, job.getProjectVersion()));
 
-        Boolean useKnownFalsePositiveFile = getUseKnownFalsePositiveFileValue(job);
         params.add(createParam(PARAM_USE_KNOWN_FALSE_POSITIVE_FILE, useKnownFalsePositiveFile.toString()));
     }
 


### PR DESCRIPTION
configure `falsePositivesUrl` to blank for packages missing known false positives file to align with the pipeline configuration.

Currently it fails because the tekton pipeline doesn't check the values of useKnownfalsePositivesFile before trying to validate the URL. Now this is fixed as we pass an empty string.