### PR TITLE
Fix/use known false positive file parameter

### DIFF
--- a/src/main/java/com/redhat/sast/api/util/input/CsvJobParser.java
+++ b/src/main/java/com/redhat/sast/api/util/input/CsvJobParser.java
@@ -134,7 +134,8 @@ public class CsvJobParser {
         return foundHeaders.values().stream().allMatch(Boolean::booleanValue);
     }
 
-    private JobCreationDto createJobFromRecord(CSVRecord record, CSVRecord headerRecord, Boolean useKnownFalsePositiveFile) {
+    private JobCreationDto createJobFromRecord(
+            CSVRecord record, CSVRecord headerRecord, Boolean useKnownFalsePositiveFile) {
         int nvrIndex = findColumnIndex(headerRecord, "nvr");
         int googleSheetIndex = findColumnIndex(headerRecord, "googleSheetUrl");
 

--- a/src/main/java/com/redhat/sast/api/util/input/CsvJobParser.java
+++ b/src/main/java/com/redhat/sast/api/util/input/CsvJobParser.java
@@ -79,7 +79,7 @@ public class CsvJobParser {
                     .filter(Predicate.not(this::isRecordEmpty))
                     .map(record -> {
                         try {
-                            return createJobFromRecord(record, headerRecord);
+                            return createJobFromRecord(record, headerRecord, useKnownFalsePositiveFile);
                         } catch (IllegalArgumentException e) {
                             LOGGER.warn("Skipping record at line {}: {}", record.getRecordNumber(), e.getMessage());
                             return null;
@@ -134,7 +134,7 @@ public class CsvJobParser {
         return foundHeaders.values().stream().allMatch(Boolean::booleanValue);
     }
 
-    private JobCreationDto createJobFromRecord(CSVRecord record, CSVRecord headerRecord) {
+    private JobCreationDto createJobFromRecord(CSVRecord record, CSVRecord headerRecord, Boolean useKnownFalsePositiveFile) {
         int nvrIndex = findColumnIndex(headerRecord, "nvr");
         int googleSheetIndex = findColumnIndex(headerRecord, "googleSheetUrl");
 
@@ -142,6 +142,7 @@ public class CsvJobParser {
         String googleSheetUrl = getFieldValue(record, googleSheetIndex);
 
         JobCreationDto job = new JobCreationDto(packageNvr, googleSheetUrl);
+        job.setUseKnownFalsePositiveFile(useKnownFalsePositiveFile);
 
         validateRequiredFields(job, record.getRecordNumber());
         return job;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,7 @@ sast.ai.workspace.shared.size=20Gi
 sast.ai.workspace.cache.size=10Gi
 
 # Cleanup configuration
-sast.ai.cleanup.completed.pipelineruns=false
+sast.ai.cleanup.completed.pipelineruns=true
 
 # URL validation HTTP client timeout configuration
 # NOTE: This service uses a separate HTTP client from other components in the application


### PR DESCRIPTION
- pass missing `useKnownFalsePositiveFile` to `createJobFromRecord()` to account for the configured value rather than the default value. This resolves the bug for the batch jobs endpoint where even after passing `useKnownFalsePositiveFile=false` it still defaulted to `true`.
- enabled completed pipelines cleanup to avoid accumulation