### PR TITLE
Feature/dataset pv setup

### DIFF
--- a/deploy/sast-ai-chart/templates/dataset-pvc.yaml
+++ b/deploy/sast-ai-chart/templates/dataset-pvc.yaml
@@ -12,6 +12,7 @@ metadata:
   {{- with (include "sast-ai.annotations" .) }}
   annotations:
     {{- . | nindent 4 }}
+    storage.kubernetes.io/reclaim-policy: "{{ .Values.dataset.storage.reclaimPolicy | default "Retain" }}"
   {{- end }}
 spec:
   accessModes:
@@ -19,9 +20,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.dataset.storage.size }}
-  {{- if .Values.dataset.storage.storageClass }}
-  storageClassName: {{ .Values.dataset.storage.storageClass }}
-  {{- end }}
+  storageClassName: {{ .Values.dataset.storage.storageClass | default "sast-dataset-storage" }}
 ---
 # Read-Only PVC for general dataset access
 apiVersion: v1
@@ -36,6 +35,7 @@ metadata:
   {{- with (include "sast-ai.annotations" .) }}
   annotations:
     {{- . | nindent 4 }}
+    storage.kubernetes.io/reclaim-policy: "{{ .Values.dataset.storage.reclaimPolicy | default "Retain" }}"
   {{- end }}
 spec:
   accessModes:
@@ -43,7 +43,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.dataset.storage.size }}
-  {{- if .Values.dataset.storage.storageClass }}
-  storageClassName: {{ .Values.dataset.storage.storageClass }}
-  {{- end }}
+  storageClassName: {{ .Values.dataset.storage.storageClass | default "sast-dataset-storage" }}
 {{- end }}

--- a/deploy/sast-ai-chart/templates/dataset-pvc.yaml
+++ b/deploy/sast-ai-chart/templates/dataset-pvc.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.dataset.storage.enabled }}
+# Read-Write PVC for authorized dataset administrators
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sast-ai.fullname" . }}-dataset-storage-rw
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sast-ai.labels" . | nindent 4 }}
+    component: dataset-storage
+    access-mode: read-write
+  {{- with (include "sast-ai.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.dataset.storage.size }}
+  {{- if .Values.dataset.storage.storageClass }}
+  storageClassName: {{ .Values.dataset.storage.storageClass }}
+  {{- end }}
+---
+# Read-Only PVC for general dataset access
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sast-ai.fullname" . }}-dataset-storage-ro
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sast-ai.labels" . | nindent 4 }}
+    component: dataset-storage
+    access-mode: read-only
+  {{- with (include "sast-ai.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: {{ .Values.dataset.storage.size }}
+  {{- if .Values.dataset.storage.storageClass }}
+  storageClassName: {{ .Values.dataset.storage.storageClass }}
+  {{- end }}
+{{- end }}

--- a/deploy/sast-ai-chart/templates/dataset-rbac.yaml
+++ b/deploy/sast-ai-chart/templates/dataset-rbac.yaml
@@ -1,0 +1,138 @@
+{{- if and .Values.dataset.storage.enabled .Values.dataset.storage.accessControl.enabled }}
+# Dataset Administrator Role - Read-Write access to dataset storage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "sast-ai.fullname" . }}-dataset-admin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sast-ai.labels" . | nindent 4 }}
+    component: dataset-access-control
+    access-level: admin
+  {{- with (include "sast-ai.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+rules:
+  # Full access to dataset PVCs
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    resourceNames: 
+      - "{{ include "sast-ai.fullname" . }}-dataset-storage-rw"
+      - "{{ include "sast-ai.fullname" . }}-dataset-storage-ro"
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Access to pods that mount dataset storage
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  # Access to configmaps for dataset configuration
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+# Dataset Reader Role - Read-Only access to dataset storage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "sast-ai.fullname" . }}-dataset-reader
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sast-ai.labels" . | nindent 4 }}
+    component: dataset-access-control
+    access-level: reader
+  {{- with (include "sast-ai.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+rules:
+  # Read-only access to dataset PVCs
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    resourceNames: 
+      - "{{ include "sast-ai.fullname" . }}-dataset-storage-ro"
+    verbs: ["get", "list", "watch"]
+  # Read-only access to pods for monitoring
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  # Read access to dataset configuration
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+# Service Account for Dataset Administrators
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sast-ai.fullname" . }}-dataset-admin-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sast-ai.labels" . | nindent 4 }}
+    component: dataset-access-control
+    access-level: admin
+  {{- with (include "sast-ai.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+---
+# Service Account for Dataset Readers
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sast-ai.fullname" . }}-dataset-reader-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sast-ai.labels" . | nindent 4 }}
+    component: dataset-access-control
+    access-level: reader
+  {{- with (include "sast-ai.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+---
+# RoleBinding for Dataset Administrators
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "sast-ai.fullname" . }}-dataset-admin-binding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sast-ai.labels" . | nindent 4 }}
+    component: dataset-access-control
+    access-level: admin
+  {{- with (include "sast-ai.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "sast-ai.fullname" . }}-dataset-admin
+subjects:
+- kind: ServiceAccount
+  name: {{ include "sast-ai.fullname" . }}-dataset-admin-sa
+  namespace: {{ .Release.Namespace }}
+---
+# RoleBinding for Dataset Readers
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "sast-ai.fullname" . }}-dataset-reader-binding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sast-ai.labels" . | nindent 4 }}
+    component: dataset-access-control
+    access-level: reader
+  {{- with (include "sast-ai.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "sast-ai.fullname" . }}-dataset-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ include "sast-ai.fullname" . }}-dataset-reader-sa
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/sast-ai-chart/templates/dataset-storageclass.yaml
+++ b/deploy/sast-ai-chart/templates/dataset-storageclass.yaml
@@ -1,0 +1,94 @@
+{{- if and .Values.dataset.storage.enabled .Values.dataset.storage.performance.createStorageClass }}
+# StorageClass for SAST dataset storage with explicit reclaim policy
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.dataset.storage.storageClass }}
+  labels:
+    {{- include "sast-ai.labels" . | nindent 4 }}
+    component: dataset-storage
+  {{- with (include "sast-ai.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+    # Storage policy documentation
+    storage.kubernetes.io/description: "StorageClass for SAST dataset storage with data retention"
+  {{- end }}
+# Provisioner - adjust based on your cluster setup
+provisioner: {{ .Values.dataset.storage.performance.provisioner }}
+# Reclaim policy - CRITICAL for data retention
+reclaimPolicy: {{ .Values.dataset.storage.reclaimPolicy }}
+# Volume binding mode
+volumeBindingMode: {{ .Values.dataset.storage.performance.volumeBindingMode | default "WaitForFirstConsumer" }}
+# Allow volume expansion
+allowVolumeExpansion: {{ .Values.dataset.storage.performance.allowVolumeExpansion | default true }}
+# Parameters for the provisioner
+parameters:
+  # File system type
+  fsType: {{ .Values.dataset.storage.performance.fsType | default "ext4" }}
+  {{- if .Values.dataset.storage.performance.parameters }}
+  {{- toYaml .Values.dataset.storage.performance.parameters | nindent 2 }}
+  {{- end }}
+---
+# Documentation ConfigMap explaining storage considerations
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sast-ai.fullname" . }}-storage-docs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sast-ai.labels" . | nindent 4 }}
+    component: dataset-storage
+    type: documentation
+data:
+  README.md: |
+    # SAST Dataset Storage Configuration
+    
+    ## Critical Storage Settings
+    
+    **Reclaim Policy**: {{ .Values.dataset.storage.reclaimPolicy }}
+    - `Retain`: Data survives PVC deletion (RECOMMENDED for datasets)
+    - `Delete`: Data is destroyed when PVC is deleted (DANGEROUS for datasets)
+    
+    **Access Mode**: {{ .Values.dataset.storage.accessMode }}
+    - `ReadWriteMany`: Multiple pods can read/write (required for SAST workflows)
+    - `ReadWriteOnce`: Single pod access only (better performance, limited use)
+    
+    ## Performance Considerations
+    
+    **Node Locality**: Pods may be scheduled on different nodes than storage
+    - Impact: Network latency for large dataset access
+    - Mitigation: Use node affinity or network-attached storage
+    
+    **Storage Class**: {{ .Values.dataset.storage.storageClass }}
+    - Provisioner: {{ .Values.dataset.storage.performance.provisioner }}
+    - Check cluster storage capabilities before deployment
+    
+    ## Validation Commands
+    
+    ```bash
+    # Check storage class configuration
+    kubectl get storageclass {{ .Values.dataset.storage.storageClass }} -o yaml
+    
+    # Verify reclaim policy
+    kubectl get storageclass -o custom-columns=NAME:.metadata.name,RECLAIM:.reclaimPolicy
+    
+    # Check PVC status
+    kubectl get pvc -l component=dataset-storage
+    
+    # Monitor storage usage
+    kubectl describe pvc {{ include "sast-ai.fullname" . }}-dataset-storage-rw
+    ```
+    
+    ## Backup Strategy
+    
+    With `reclaimPolicy: Retain`, data survives PVC deletion but consider:
+    - CSI snapshots for point-in-time recovery
+    - DVC integration for version control
+    - External backup to S3/Azure/GCS
+    
+    ## Troubleshooting
+    
+    **PVC Pending**: Check storage class exists and provisioner is available
+    **Performance Issues**: Consider node affinity, storage type, and network setup
+    **Data Loss**: With `Retain` policy, manually delete PV after PVC deletion
+{{- end }}

--- a/deploy/sast-ai-chart/values.yaml
+++ b/deploy/sast-ai-chart/values.yaml
@@ -244,8 +244,15 @@ dataset:
     enabled: false
     # Storage size for dataset PVCs
     size: 100Gi
-    # Storage class (empty for default)
-    storageClass: ""
+    # Storage class configuration
+    storageClass: "sast-dataset-storage"
+    reclaimPolicy: "Retain"
+    # ReadWriteMany required for multi-pod access (may impact performance)
+    accessMode: "ReadWriteMany"
+    performance:
+      createStorageClass: true
+      provisioner: "kubernetes.io/no-provisioner"
+      # Alternative: "csi-driver" for dynamic provisioning
     # Access control configuration
     accessControl:
       # Enable RBAC for dataset access

--- a/deploy/sast-ai-chart/values.yaml
+++ b/deploy/sast-ai-chart/values.yaml
@@ -235,4 +235,18 @@ imagePullSecrets: []
 labels: {}
 
 ## Additional annotations for all resources
-annotations: {} 
+annotations: {}
+
+## Dataset storage configuration
+dataset:
+  storage:
+    # Enable dataset storage PVCs
+    enabled: false
+    # Storage size for dataset PVCs
+    size: 100Gi
+    # Storage class (empty for default)
+    storageClass: ""
+    # Access control configuration
+    accessControl:
+      # Enable RBAC for dataset access
+      enabled: false 

--- a/src/main/java/com/redhat/sast/api/service/DatasetStorageService.java
+++ b/src/main/java/com/redhat/sast/api/service/DatasetStorageService.java
@@ -4,7 +4,7 @@ import com.redhat.sast.api.platform.KubernetesResourceManager;
 import com.redhat.sast.api.v1.dto.response.DatasetStorageHealthResponseDto;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -12,11 +12,11 @@ import lombok.extern.slf4j.Slf4j;
  * Provides high-level operations for dataset storage management.
  */
 @ApplicationScoped
+@RequiredArgsConstructor
 @Slf4j
 public class DatasetStorageService {
 
-    @Inject
-    KubernetesResourceManager kubernetesResourceManager;
+    private final KubernetesResourceManager kubernetesResourceManager;
 
     /**
      * Initializes dataset storage if enabled and not already present.

--- a/src/main/java/com/redhat/sast/api/service/DatasetStorageService.java
+++ b/src/main/java/com/redhat/sast/api/service/DatasetStorageService.java
@@ -1,0 +1,53 @@
+package com.redhat.sast.api.service;
+
+import com.redhat.sast.api.platform.KubernetesResourceManager;
+import com.redhat.sast.api.v1.dto.response.DatasetStorageHealthResponseDto;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service for managing dataset storage operations and health checks.
+ * Provides high-level operations for dataset storage management.
+ */
+@ApplicationScoped
+@Slf4j
+public class DatasetStorageService {
+
+    @Inject
+    KubernetesResourceManager kubernetesResourceManager;
+
+    /**
+     * Initializes dataset storage if enabled and not already present.
+     *
+     * @return true if storage is ready (either already existed or was created)
+     */
+    public boolean initializeDatasetStorage() {
+        LOGGER.debug("Initializing dataset storage...");
+
+        if (kubernetesResourceManager.isDatasetStorageReady()) {
+            LOGGER.debug("Dataset storage is already ready");
+            return true;
+        }
+
+        boolean created = kubernetesResourceManager.createDatasetStoragePVCs();
+        if (created) {
+            LOGGER.debug("Dataset storage initialized successfully");
+            return true;
+        } else {
+            LOGGER.warn("Failed to initialize dataset storage");
+            return false;
+        }
+    }
+
+    /**
+     * Checks the health status of dataset storage.
+     *
+     * @return DatasetStorageHealthResponseDto with status information
+     */
+    public DatasetStorageHealthResponseDto checkStorageHealth() {
+        boolean isReady = kubernetesResourceManager.isDatasetStorageReady();
+        return new DatasetStorageHealthResponseDto(isReady);
+    }
+}

--- a/src/main/java/com/redhat/sast/api/v1/dto/response/DatasetStorageHealthResponseDto.java
+++ b/src/main/java/com/redhat/sast/api/v1/dto/response/DatasetStorageHealthResponseDto.java
@@ -1,0 +1,30 @@
+package com.redhat.sast.api.v1.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DatasetStorageHealthResponseDto {
+
+    @JsonProperty("ready")
+    private boolean ready;
+
+    @JsonProperty("status")
+    private String status;
+
+    @JsonProperty("timestamp")
+    private LocalDateTime timestamp;
+
+    public DatasetStorageHealthResponseDto(boolean ready) {
+        this.ready = ready;
+        this.status = ready ? "READY" : "NOT_READY";
+        this.timestamp = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/redhat/sast/api/v1/dto/response/DatasetStorageInitializationResponseDto.java
+++ b/src/main/java/com/redhat/sast/api/v1/dto/response/DatasetStorageInitializationResponseDto.java
@@ -1,0 +1,30 @@
+package com.redhat.sast.api.v1.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DatasetStorageInitializationResponseDto {
+
+    @JsonProperty("success")
+    private boolean success;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("timestamp")
+    private LocalDateTime timestamp;
+
+    public DatasetStorageInitializationResponseDto(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+        this.timestamp = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/redhat/sast/api/v1/dto/response/ErrorResponseDto.java
+++ b/src/main/java/com/redhat/sast/api/v1/dto/response/ErrorResponseDto.java
@@ -1,0 +1,30 @@
+package com.redhat.sast.api.v1.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorResponseDto {
+
+    @JsonProperty("error")
+    private String error;
+
+    @JsonProperty("details")
+    private String details;
+
+    @JsonProperty("timestamp")
+    private LocalDateTime timestamp;
+
+    public ErrorResponseDto(String error, String details) {
+        this.error = error;
+        this.details = details;
+        this.timestamp = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/redhat/sast/api/v1/resource/DatasetStorageResource.java
+++ b/src/main/java/com/redhat/sast/api/v1/resource/DatasetStorageResource.java
@@ -1,0 +1,74 @@
+package com.redhat.sast.api.v1.resource;
+
+import com.redhat.sast.api.service.DatasetStorageService;
+import com.redhat.sast.api.v1.dto.response.DatasetStorageHealthResponseDto;
+import com.redhat.sast.api.v1.dto.response.DatasetStorageInitializationResponseDto;
+import com.redhat.sast.api.v1.dto.response.ErrorResponseDto;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * REST API endpoints for dataset storage management and monitoring.
+ */
+@Path("/api/v1/dataset-storage")
+@Produces(MediaType.APPLICATION_JSON)
+@Slf4j
+public class DatasetStorageResource {
+
+    @Inject
+    DatasetStorageService datasetStorageService;
+
+    /**
+     * Health check endpoint for dataset storage.
+     *
+     * @return health status of dataset storage
+     */
+    @GET
+    @Path("/health")
+    public Response getStorageHealth() {
+        try {
+            DatasetStorageHealthResponseDto health = datasetStorageService.checkStorageHealth();
+            return Response.ok(health).build();
+        } catch (Exception e) {
+            LOGGER.error("Failed to check dataset storage health", e);
+            return Response.serverError()
+                    .entity(new ErrorResponseDto("Failed to check storage health", e.getMessage()))
+                    .build();
+        }
+    }
+
+    /**
+     * Initialize dataset storage PVCs.
+     *
+     * @return result of storage initialization
+     */
+    @POST
+    @Path("/initialize")
+    public Response initializeStorage() {
+        try {
+            boolean initialized = datasetStorageService.initializeDatasetStorage();
+            if (initialized) {
+                return Response.ok(new DatasetStorageInitializationResponseDto(
+                                true, "Dataset storage initialized successfully"))
+                        .build();
+            } else {
+                return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                        .entity(new DatasetStorageInitializationResponseDto(
+                                false, "Failed to initialize dataset storage"))
+                        .build();
+            }
+        } catch (Exception e) {
+            LOGGER.error("Failed to initialize dataset storage", e);
+            return Response.serverError()
+                    .entity(new ErrorResponseDto("Failed to initialize storage", e.getMessage()))
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/redhat/sast/api/v1/resource/DatasetStorageResource.java
+++ b/src/main/java/com/redhat/sast/api/v1/resource/DatasetStorageResource.java
@@ -5,13 +5,13 @@ import com.redhat.sast.api.v1.dto.response.DatasetStorageHealthResponseDto;
 import com.redhat.sast.api.v1.dto.response.DatasetStorageInitializationResponseDto;
 import com.redhat.sast.api.v1.dto.response.ErrorResponseDto;
 
-import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -19,11 +19,11 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Path("/api/v1/dataset-storage")
 @Produces(MediaType.APPLICATION_JSON)
+@RequiredArgsConstructor
 @Slf4j
 public class DatasetStorageResource {
 
-    @Inject
-    DatasetStorageService datasetStorageService;
+    private final DatasetStorageService datasetStorageService;
 
     /**
      * Health check endpoint for dataset storage.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,3 +38,7 @@ url-validation.request-timeout=30s
 sast.ai.batch.job.polling.interval=5000
 sast.ai.batch.job.timeout=3600000
 
+# Dataset storage configuration
+sast.ai.dataset.storage.enabled=false
+sast.ai.dataset.storage.size=100Gi
+


### PR DESCRIPTION
- add dataset storage PVC configuration to Helm chart
- add RBAC configuration for dataset storage access
- extend `KubernetesResourceManager` with dataset
- add dataset storage configuration, service layer, and monitoring endpoints

Optional tasks: Storage usage and access patter monitoring, Automated backup strategy: currently skipped due to added complexity and significant expansion of current implementation. Will be revisited as part of the following [sub-tasks](https://issues.redhat.com/browse/APPENG-3708).   

[Jira ticket](https://issues.redhat.com/browse/APPENG-3710)