### PR TITLE
Add integration tests and support for public GitHub repo scans

### DIFF
--- a/src/main/java/com/redhat/sast/api/platform/PipelineParameterMapper.java
+++ b/src/main/java/com/redhat/sast/api/platform/PipelineParameterMapper.java
@@ -150,7 +150,12 @@ public class PipelineParameterMapper {
                 params.add(createParam(PARAM_SARIF_URI, job.getSarifUri())); // Full OCI artifact URI for Konflux SARIF
                 params.add(createParam(PARAM_GIT_REVISION, job.getGitRevision()));
             }
-            default -> params.add(createParam(PARAM_INPUT_REPORT_FILE_PATH, job.getGSheetUrl()));
+            default -> {
+                params.add(createParam(PARAM_INPUT_REPORT_FILE_PATH, job.getGSheetUrl()));
+                if (job.getGitRevision() != null) {
+                    params.add(createParam(PARAM_GIT_REVISION, job.getGitRevision()));
+                }
+            }
         }
     }
 

--- a/src/main/java/com/redhat/sast/api/service/JobService.java
+++ b/src/main/java/com/redhat/sast/api/service/JobService.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.context.ManagedExecutor;
 
 import com.redhat.sast.api.common.constants.ApplicationConstants;
@@ -89,28 +90,24 @@ public class JobService {
     }
 
     private void validateAndPrepare(JobCreationDto jobCreationDto) {
-        boolean hasSourceCodeUrl =
-                ApplicationConstants.IS_NOT_NULL_AND_NOT_BLANK.test(jobCreationDto.getSourceCodeUrl());
-        boolean hasCommitId = ApplicationConstants.IS_NOT_NULL_AND_NOT_BLANK.test(jobCreationDto.getCommitId());
+        boolean hasSourceCodeUrl = StringUtils.isNotBlank(jobCreationDto.getSourceCodeUrl());
+        boolean hasCommitId = StringUtils.isNotBlank(jobCreationDto.getCommitId());
 
-        if (hasSourceCodeUrl) {
-            if (!hasCommitId) {
-                throw new IllegalArgumentException("commitId is required when sourceCodeUrl is provided");
-            }
-            if (!ApplicationConstants.IS_NOT_NULL_AND_NOT_BLANK.test(jobCreationDto.getPackageNvr())) {
+        if (hasSourceCodeUrl && hasCommitId) {
+            if (StringUtils.isBlank(jobCreationDto.getPackageNvr())) {
                 String orgRepo = extractOrgAndRepo(jobCreationDto.getSourceCodeUrl());
                 String shortCommit = jobCreationDto.getCommitId().substring(0, 7);
                 jobCreationDto.setPackageNvr(orgRepo + "-" + shortCommit);
             }
-        } else {
-            if (!ApplicationConstants.IS_NOT_NULL_AND_NOT_BLANK.test(jobCreationDto.getPackageNvr())) {
-                throw new IllegalArgumentException("packageNvr is required when sourceCodeUrl is not provided");
-            }
+        } else if (hasSourceCodeUrl) {
+            throw new IllegalArgumentException("commitId is required when sourceCodeUrl is provided");
+        } else if (StringUtils.isBlank(jobCreationDto.getPackageNvr())) {
+            throw new IllegalArgumentException("packageNvr is required when sourceCodeUrl is not provided");
         }
     }
 
     private String extractOrgAndRepo(String sourceCodeUrl) {
-        String path = sourceCodeUrl.replaceFirst("https?://[^/]+/", "");
+        String path = sourceCodeUrl.trim().replaceFirst("https?://[^/]+/", "");
         if (path.endsWith(".git")) {
             path = path.substring(0, path.length() - 4);
         }

--- a/src/main/java/com/redhat/sast/api/service/JobService.java
+++ b/src/main/java/com/redhat/sast/api/service/JobService.java
@@ -122,7 +122,7 @@ public class JobService {
     }
 
     private String extractOrgAndRepo(@Nonnull String sourceCodeUrl) {
-        String path = sourceCodeUrl.trim().replaceFirst("https?://[^/]+/", "");
+        String path = sourceCodeUrl.trim().replaceFirst("(https?|git)://[^/]+/", "");
         if (path.endsWith(".git")) {
             path = path.substring(0, path.length() - 4);
         }
@@ -315,10 +315,7 @@ public class JobService {
     }
 
     private String extractRepoName(String sourceCodeUrl) {
-        String path = sourceCodeUrl.replaceFirst("https?://[^/]+/", "");
-        if (path.endsWith(".git")) {
-            path = path.substring(0, path.length() - 4);
-        }
+        String path = extractOrgAndRepo(sourceCodeUrl);
         int lastSlash = path.lastIndexOf('/');
         return lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
     }

--- a/src/main/java/com/redhat/sast/api/service/JobService.java
+++ b/src/main/java/com/redhat/sast/api/service/JobService.java
@@ -112,7 +112,7 @@ public class JobService {
         }
     }
 
-    private void ensurePackageNvr(JobCreationDto dto, String repoUrl, String revision) {
+    private void ensurePackageNvr(@Nonnull JobCreationDto dto, @Nonnull String repoUrl, @Nonnull String revision) {
         if (StringUtils.isNotBlank(dto.getPackageNvr())) {
             return;
         }
@@ -121,7 +121,7 @@ public class JobService {
         dto.setPackageNvr(orgRepo + "-" + shortRevision);
     }
 
-    private String extractOrgAndRepo(String sourceCodeUrl) {
+    private String extractOrgAndRepo(@Nonnull String sourceCodeUrl) {
         String path = sourceCodeUrl.trim().replaceFirst("https?://[^/]+/", "");
         if (path.endsWith(".git")) {
             path = path.substring(0, path.length() - 4);

--- a/src/main/java/com/redhat/sast/api/service/JobService.java
+++ b/src/main/java/com/redhat/sast/api/service/JobService.java
@@ -40,6 +40,8 @@ public class JobService {
     private final EventBroadcastService eventBroadcastService;
 
     public JobResponseDto createJob(JobCreationDto jobCreationDto) {
+        validateAndPrepare(jobCreationDto);
+
         String packageNvr = jobCreationDto.getPackageNvr();
         boolean forceRescan = jobCreationDto.getForceRescan();
 
@@ -84,6 +86,35 @@ public class JobService {
         });
 
         return convertToResponseDto(job);
+    }
+
+    private void validateAndPrepare(JobCreationDto jobCreationDto) {
+        boolean hasSourceCodeUrl =
+                ApplicationConstants.IS_NOT_NULL_AND_NOT_BLANK.test(jobCreationDto.getSourceCodeUrl());
+        boolean hasCommitId = ApplicationConstants.IS_NOT_NULL_AND_NOT_BLANK.test(jobCreationDto.getCommitId());
+
+        if (hasSourceCodeUrl) {
+            if (!hasCommitId) {
+                throw new IllegalArgumentException("commitId is required when sourceCodeUrl is provided");
+            }
+            if (!ApplicationConstants.IS_NOT_NULL_AND_NOT_BLANK.test(jobCreationDto.getPackageNvr())) {
+                String orgRepo = extractOrgAndRepo(jobCreationDto.getSourceCodeUrl());
+                String shortCommit = jobCreationDto.getCommitId().substring(0, 7);
+                jobCreationDto.setPackageNvr(orgRepo + "-" + shortCommit);
+            }
+        } else {
+            if (!ApplicationConstants.IS_NOT_NULL_AND_NOT_BLANK.test(jobCreationDto.getPackageNvr())) {
+                throw new IllegalArgumentException("packageNvr is required when sourceCodeUrl is not provided");
+            }
+        }
+    }
+
+    private String extractOrgAndRepo(String sourceCodeUrl) {
+        String path = sourceCodeUrl.replaceFirst("https?://[^/]+/", "");
+        if (path.endsWith(".git")) {
+            path = path.substring(0, path.length() - 4);
+        }
+        return path;
     }
 
     /**
@@ -246,19 +277,33 @@ public class JobService {
 
         job.setPackageNvr(jobCreationDto.getPackageNvr());
 
-        job.setProjectName(nvrResolutionService.resolveProjectName(jobCreationDto.getPackageNvr()));
-        job.setProjectVersion(nvrResolutionService.resolveProjectVersion(jobCreationDto.getPackageNvr()));
-        job.setPackageName(nvrResolutionService.resolvePackageName(jobCreationDto.getPackageNvr()));
+        if (ApplicationConstants.IS_NOT_NULL_AND_NOT_BLANK.test(jobCreationDto.getSourceCodeUrl())) {
+            String repoName = extractRepoName(jobCreationDto.getSourceCodeUrl());
+            String shortCommit = jobCreationDto.getCommitId().substring(0, 7);
+            job.setProjectName(repoName);
+            job.setProjectVersion(shortCommit);
+            job.setPackageName(repoName);
+        } else {
+            job.setProjectName(nvrResolutionService.resolveProjectName(jobCreationDto.getPackageNvr()));
+            job.setProjectVersion(nvrResolutionService.resolveProjectVersion(jobCreationDto.getPackageNvr()));
+            job.setPackageName(nvrResolutionService.resolvePackageName(jobCreationDto.getPackageNvr()));
+        }
 
-        // Handle different input source types based on DTO content
         configureInputSource(job, jobCreationDto);
 
         job.setSubmittedBy(jobCreationDto.getSubmittedBy() != null ? jobCreationDto.getSubmittedBy() : "unknown");
-
         job.setAggregateResultsGSheet(jobCreationDto.getAggregateResultsGSheet());
-
         job.setStatus(JobStatus.PENDING);
         return job;
+    }
+
+    private String extractRepoName(String sourceCodeUrl) {
+        String path = sourceCodeUrl.replaceFirst("https?://[^/]+/", "");
+        if (path.endsWith(".git")) {
+            path = path.substring(0, path.length() - 4);
+        }
+        int lastSlash = path.lastIndexOf('/');
+        return lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
     }
 
     /**
@@ -314,12 +359,19 @@ public class JobService {
             job.setInputSourceType(InputSourceType.GOOGLE_SHEET);
             job.setGSheetUrl(inputSourceUrl);
 
-            // Resolve package source and known FP URLs using NVR
-            job.setPackageSourceCodeUrl(nvrResolutionService.resolveSourceCodeUrl(jobCreationDto.getPackageNvr()));
-            job.setKnownFalsePositivesUrl(
-                    nvrResolutionService.resolveKnownFalsePositivesUrl(jobCreationDto.getPackageNvr()));
-
-            LOGGER.debug("Configured job as GOOGLE_SHEET with URL: {}", inputSourceUrl);
+            if (ApplicationConstants.IS_NOT_NULL_AND_NOT_BLANK.test(jobCreationDto.getSourceCodeUrl())) {
+                job.setPackageSourceCodeUrl(jobCreationDto.getSourceCodeUrl());
+                job.setGitRevision(jobCreationDto.getCommitId());
+                LOGGER.debug(
+                        "Configured job as GOOGLE_SHEET with sourceCodeUrl: {}, commitId: {}",
+                        jobCreationDto.getSourceCodeUrl(),
+                        jobCreationDto.getCommitId());
+            } else {
+                job.setPackageSourceCodeUrl(nvrResolutionService.resolveSourceCodeUrl(jobCreationDto.getPackageNvr()));
+                job.setKnownFalsePositivesUrl(
+                        nvrResolutionService.resolveKnownFalsePositivesUrl(jobCreationDto.getPackageNvr()));
+                LOGGER.debug("Configured job as GOOGLE_SHEET with URL: {}", inputSourceUrl);
+            }
             return;
         }
 
@@ -371,8 +423,11 @@ public class JobService {
     }
 
     private boolean shouldUseFalsePositiveFile(JobCreationDto jobCreationDto) {
-        Boolean useFromDto = jobCreationDto.getUseKnownFalsePositiveFile();
+        if (ApplicationConstants.IS_NOT_NULL_AND_NOT_BLANK.test(jobCreationDto.getSourceCodeUrl())) {
+            return false;
+        }
 
+        Boolean useFromDto = jobCreationDto.getUseKnownFalsePositiveFile();
         if (useFromDto != null) {
             return useFromDto;
         }

--- a/src/main/java/com/redhat/sast/api/service/JobService.java
+++ b/src/main/java/com/redhat/sast/api/service/JobService.java
@@ -440,7 +440,7 @@ public class JobService {
         if (StringUtils.isNotBlank(dto.getSourceCodeUrl())) {
             return false;
         }
-        return dto.getUseKnownFalsePositiveFile() != null ? dto.getUseKnownFalsePositiveFile() : true;
+        return !Boolean.FALSE.equals(dto.getUseKnownFalsePositiveFile());
     }
 
     private JobResponseDto convertToResponseDto(Job job) {

--- a/src/main/java/com/redhat/sast/api/service/JobService.java
+++ b/src/main/java/com/redhat/sast/api/service/JobService.java
@@ -89,21 +89,36 @@ public class JobService {
         return convertToResponseDto(job);
     }
 
-    private void validateAndPrepare(JobCreationDto jobCreationDto) {
-        boolean hasSourceCodeUrl = StringUtils.isNotBlank(jobCreationDto.getSourceCodeUrl());
-        boolean hasCommitId = StringUtils.isNotBlank(jobCreationDto.getCommitId());
+    private void validateAndPrepare(JobCreationDto dto) {
+        boolean hasSourceCodeUrl = StringUtils.isNotBlank(dto.getSourceCodeUrl());
+        boolean hasCommitId = StringUtils.isNotBlank(dto.getCommitId());
+        boolean hasInputSourceUrl = StringUtils.isNotBlank(dto.getInputSourceUrl());
+        boolean hasGitRevision = StringUtils.isNotBlank(dto.getGitRevision());
 
-        if (hasSourceCodeUrl && hasCommitId) {
-            if (StringUtils.isBlank(jobCreationDto.getPackageNvr())) {
-                String orgRepo = extractOrgAndRepo(jobCreationDto.getSourceCodeUrl());
-                String shortCommit = jobCreationDto.getCommitId().substring(0, 7);
-                jobCreationDto.setPackageNvr(orgRepo + "-" + shortCommit);
+        if (hasSourceCodeUrl) {
+            if (hasCommitId) {
+                ensurePackageNvr(dto, dto.getSourceCodeUrl(), dto.getCommitId());
+                return;
             }
-        } else if (hasSourceCodeUrl) {
             throw new IllegalArgumentException("commitId is required when sourceCodeUrl is provided");
-        } else if (StringUtils.isBlank(jobCreationDto.getPackageNvr())) {
-            throw new IllegalArgumentException("packageNvr is required when sourceCodeUrl is not provided");
         }
+        if (hasInputSourceUrl && hasGitRevision) {
+            ensurePackageNvr(dto, dto.getInputSourceUrl(), dto.getGitRevision());
+            return;
+        }
+        if (StringUtils.isBlank(dto.getPackageNvr())) {
+            throw new IllegalArgumentException(
+                    "Either packageNvr, sourceCodeUrl with commitId, or inputSourceUrl with gitRevision must be provided");
+        }
+    }
+
+    private void ensurePackageNvr(JobCreationDto dto, String repoUrl, String revision) {
+        if (StringUtils.isNotBlank(dto.getPackageNvr())) {
+            return;
+        }
+        String orgRepo = extractOrgAndRepo(repoUrl);
+        String shortRevision = revision.substring(0, Math.min(7, revision.length()));
+        dto.setPackageNvr(orgRepo + "-" + shortRevision);
     }
 
     private String extractOrgAndRepo(String sourceCodeUrl) {
@@ -269,29 +284,34 @@ public class JobService {
         return job;
     }
 
-    private Job getJobFromDto(JobCreationDto jobCreationDto) {
+    private Job getJobFromDto(JobCreationDto dto) {
         Job job = new Job();
+        job.setPackageNvr(dto.getPackageNvr());
 
-        job.setPackageNvr(jobCreationDto.getPackageNvr());
-
-        if (ApplicationConstants.IS_NOT_NULL_AND_NOT_BLANK.test(jobCreationDto.getSourceCodeUrl())) {
-            String repoName = extractRepoName(jobCreationDto.getSourceCodeUrl());
-            String shortCommit = jobCreationDto.getCommitId().substring(0, 7);
-            job.setProjectName(repoName);
-            job.setProjectVersion(shortCommit);
-            job.setPackageName(repoName);
+        if (StringUtils.isNotBlank(dto.getSourceCodeUrl())) {
+            setProjectFieldsFromUrl(job, dto.getSourceCodeUrl(), dto.getCommitId());
+        } else if (StringUtils.isNotBlank(dto.getSarifUri()) && StringUtils.isNotBlank(dto.getInputSourceUrl())) {
+            setProjectFieldsFromUrl(job, dto.getInputSourceUrl(), dto.getGitRevision());
         } else {
-            job.setProjectName(nvrResolutionService.resolveProjectName(jobCreationDto.getPackageNvr()));
-            job.setProjectVersion(nvrResolutionService.resolveProjectVersion(jobCreationDto.getPackageNvr()));
-            job.setPackageName(nvrResolutionService.resolvePackageName(jobCreationDto.getPackageNvr()));
+            String nvr = dto.getPackageNvr();
+            job.setProjectName(nvrResolutionService.resolveProjectName(nvr));
+            job.setProjectVersion(nvrResolutionService.resolveProjectVersion(nvr));
+            job.setPackageName(nvrResolutionService.resolvePackageName(nvr));
         }
 
-        configureInputSource(job, jobCreationDto);
-
-        job.setSubmittedBy(jobCreationDto.getSubmittedBy() != null ? jobCreationDto.getSubmittedBy() : "unknown");
-        job.setAggregateResultsGSheet(jobCreationDto.getAggregateResultsGSheet());
+        configureInputSource(job, dto);
+        job.setSubmittedBy(dto.getSubmittedBy() != null ? dto.getSubmittedBy() : "unknown");
+        job.setAggregateResultsGSheet(dto.getAggregateResultsGSheet());
         job.setStatus(JobStatus.PENDING);
         return job;
+    }
+
+    private void setProjectFieldsFromUrl(Job job, String repoUrl, String revision) {
+        String repoName = extractRepoName(repoUrl);
+        String shortRevision = revision != null ? revision.substring(0, Math.min(7, revision.length())) : "";
+        job.setProjectName(repoName);
+        job.setProjectVersion(shortRevision);
+        job.setPackageName(repoName);
     }
 
     private String extractRepoName(String sourceCodeUrl) {
@@ -419,17 +439,11 @@ public class JobService {
         }
     }
 
-    private boolean shouldUseFalsePositiveFile(JobCreationDto jobCreationDto) {
-        if (ApplicationConstants.IS_NOT_NULL_AND_NOT_BLANK.test(jobCreationDto.getSourceCodeUrl())) {
+    private boolean shouldUseFalsePositiveFile(JobCreationDto dto) {
+        if (StringUtils.isNotBlank(dto.getSourceCodeUrl())) {
             return false;
         }
-
-        Boolean useFromDto = jobCreationDto.getUseKnownFalsePositiveFile();
-        if (useFromDto != null) {
-            return useFromDto;
-        }
-
-        return true;
+        return dto.getUseKnownFalsePositiveFile() != null ? dto.getUseKnownFalsePositiveFile() : true;
     }
 
     private JobResponseDto convertToResponseDto(Job job) {

--- a/src/main/java/com/redhat/sast/api/v1/dto/request/JobCreationDto.java
+++ b/src/main/java/com/redhat/sast/api/v1/dto/request/JobCreationDto.java
@@ -2,7 +2,6 @@ package com.redhat.sast.api.v1.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,7 +12,6 @@ import lombok.NoArgsConstructor;
 public class JobCreationDto {
 
     @JsonProperty("packageNvr")
-    @NotBlank(message = "Package NVR cannot be null or empty.")
     private String packageNvr;
 
     @JsonProperty("inputSourceUrl")
@@ -33,6 +31,12 @@ public class JobCreationDto {
 
     @JsonProperty("sarifUri")
     private String sarifUri;
+
+    @JsonProperty("sourceCodeUrl")
+    private String sourceCodeUrl;
+
+    @JsonProperty("commitId")
+    private String commitId;
 
     @JsonProperty("aggregateResultsGSheet")
     private String aggregateResultsGSheet;

--- a/src/test/java/com/redhat/sast/api/testdata/JobTestDataBuilder.java
+++ b/src/test/java/com/redhat/sast/api/testdata/JobTestDataBuilder.java
@@ -9,6 +9,9 @@ public class JobTestDataBuilder {
             "https://docs.google.com/spreadsheets/d/1Emi-AtukrJ53rVKDsll3ZNdExykkZoX7HlLzZX1tHJ4/edit?usp=sharing";
     private Boolean useKnownFalsePositiveFile = false;
     private String aggregateResultsGSheet = null;
+    private String sourceCodeUrl = null;
+    private String commitId = null;
+    private Boolean forceRescan = null;
 
     public static JobTestDataBuilder aJob() {
         return new JobTestDataBuilder();
@@ -34,10 +37,30 @@ public class JobTestDataBuilder {
         return this;
     }
 
+    public JobTestDataBuilder withSourceCodeUrl(String sourceCodeUrl) {
+        this.sourceCodeUrl = sourceCodeUrl;
+        return this;
+    }
+
+    public JobTestDataBuilder withCommitId(String commitId) {
+        this.commitId = commitId;
+        return this;
+    }
+
+    public JobTestDataBuilder withForceRescan(Boolean forceRescan) {
+        this.forceRescan = forceRescan;
+        return this;
+    }
+
     public JobCreationDto build() {
         JobCreationDto dto = new JobCreationDto(packageNvr, inputSourceUrl);
         dto.setUseKnownFalsePositiveFile(useKnownFalsePositiveFile);
         dto.setAggregateResultsGSheet(aggregateResultsGSheet);
+        dto.setSourceCodeUrl(sourceCodeUrl);
+        dto.setCommitId(commitId);
+        if (forceRescan != null) {
+            dto.setForceRescan(forceRescan);
+        }
         return dto;
     }
 

--- a/src/test/java/com/redhat/sast/api/v1/resource/JobResourceIT.java
+++ b/src/test/java/com/redhat/sast/api/v1/resource/JobResourceIT.java
@@ -262,6 +262,44 @@ class JobResourceIT {
     }
 
     @Test
+    @DisplayName("Should create job with sourceCodeUrl and commitId, auto-generating packageNvr")
+    void shouldCreateJobWithSourceCodeUrlAndCommitId() {
+        JobCreationDto jobRequest = JobTestDataBuilder.aJob()
+                .withPackageNvr(null)
+                .withSourceCodeUrl("https://github.com/NVIDIA/OpenShell")
+                .withCommitId("f4184049abdec74e699361fb344036931db70035")
+                .withForceRescan(true)
+                .build();
+
+        given().contentType(ContentType.JSON)
+                .body(jobRequest)
+                .when()
+                .post("/api/v1/jobs/simple")
+                .then()
+                .statusCode(201)
+                .body("jobId", notNullValue())
+                .body("packageNvr", equalTo("NVIDIA/OpenShell-f418404"))
+                .body("projectName", equalTo("OpenShell"))
+                .body("status", equalTo("PENDING"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 when sourceCodeUrl is provided without commitId")
+    void shouldReturn400WhenSourceCodeUrlWithoutCommitId() {
+        JobCreationDto jobRequest = JobTestDataBuilder.aJob()
+                .withPackageNvr(null)
+                .withSourceCodeUrl("https://github.com/NVIDIA/OpenShell")
+                .build();
+
+        given().contentType(ContentType.JSON)
+                .body(jobRequest)
+                .when()
+                .post("/api/v1/jobs/simple")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
     @DisplayName("Should create simple job with aggregate results Google Sheet URL")
     void shouldCreateSimpleJobWithAggregateResultsGSheet() {
         JobCreationDto jobRequest = JobTestDataBuilder.aJob()


### PR DESCRIPTION
### Description
This pull request includes the following changes:
- Implemented support for scanning public GitHub repositories using the `sourceCodeUrl` and `commitId` fields.
- Added integration tests for job creation using `sourceCodeUrl` and `commitId` fields.